### PR TITLE
Fix pluralization in chapter load message

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -157,7 +157,7 @@ local function constructor(): quill
 		run_chapter_lifecycle(chapter_list, "init")
 		run_chapter_lifecycle(chapter_list, "start")
 
-		print(`[quill] Loaded {#chapter_list} chapters.`)
+		print(`[quill] Loaded {#chapter_list} {(#chapter_list == 1 and "chapter" or "chapters")}.`)
 	end
 
 	return self


### PR DESCRIPTION
This PR updates the chapter loading message to correctly display "chapter" when only one chapter is loaded, and "chapters" otherwise. Improves readability and polish in console output.