### PR TITLE
Correct typo in context_subscriber export

### DIFF
--- a/crates/logger/lib/init.luau
+++ b/crates/logger/lib/init.luau
@@ -231,7 +231,7 @@ local logger = table.freeze {
 
     console_subscriber = console_subscriber,
     traceback_subscriber = traceback_subscriber,
-    context_subscriebr = context_subscriber,
+    context_subscriber = context_subscriber,
 }
 
 return logger


### PR DESCRIPTION
Correct spelling of context_subscriber, previous "context_subscriebr".